### PR TITLE
Fix scipy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "numpy>=1.18",
-        "scipy>=1.41",
+        "scipy>=1.4.1",
         "matplotlib>=3.2",
         "pandas>=1.0",
         "future>=0.18"


### PR DESCRIPTION
Scipy doesn't have a version 1.41, and because of the naming conventions 1.8.0 doesn't satisfy. I tested with 1.4.1 and it works fine, so this change will make install work with pip.