### PR TITLE
Include dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,10 @@ setup(
         "scipy>=1.4.1",
         "matplotlib>=3.2",
         "pandas>=1.0",
-        "future>=0.18"
+        "future>=0.18",
+        "scikit-learn",
+        "scikit-image",
+        "statsmodels"
     ],
     include_package_data=True
 )


### PR DESCRIPTION
The setup.py file includes some but not all of the dependencies required to import pyto after installing it. 
Missing dependencies include: scikit-learn, scikit-image, statsmodels.
